### PR TITLE
Fix rescue function parameters

### DIFF
--- a/ext/cbor/buffer_class.c
+++ b/ext/cbor/buffer_class.c
@@ -254,10 +254,11 @@ static VALUE read_until_eof_rescue(VALUE args)
     return Qnil;
 }
 
-static VALUE read_until_eof_error(VALUE args)
+static VALUE read_until_eof_error(VALUE args, VALUE error)
 {
     /* ignore EOFError */
     UNUSED(args);
+    UNUSED(error);
     return Qnil;
 }
 

--- a/ext/cbor/unpacker_class.c
+++ b/ext/cbor/unpacker_class.c
@@ -261,9 +261,10 @@ static VALUE Unpacker_each_impl(VALUE self)
     }
 }
 
-static VALUE Unpacker_rescue_EOFError(VALUE self)
+static VALUE Unpacker_rescue_EOFError(VALUE self, VALUE error)
 {
     UNUSED(self);
+    UNUSED(error);
     return Qnil;
 }
 


### PR DESCRIPTION
I couldn't find official documentation for `rb_rescue2` but [`rb_rescue` calls it](https://github.com/ruby/ruby/blob/fbd55120f3c58dc7d16b3870a8f36f07277bb338/eval.c#L966) and [its documentation](https://docs.ruby-lang.org/en/master/extension_rdoc.html) says:

> it calls func2 with arg2 as the first argument and the exception object as the second argument

(in this case the error would be `rb_eEOFError` instead of `rb_eStandardError` from what I can tell)

I copied the `UNUSED` as I assume it's to silence some linter. clang doesn't say anything even if I remove the line.

Please note that I didn't do any testing beyond `rake build` and `rake spec`. I did test `printf` on both functions but only saw the output for `buffer_class.c` so I guess the error path on `unpacker_class.c` is never hit (or the output got eaten somewhere? I don't really do c).

Supposedly resolves #16... but I see some more warnings:

```
compiling ../../../../ext/cbor/unpacker.c
../../../../ext/cbor/unpacker.c:305:5: warning: 'SOMEBODY_FIXED_LDEXP' is not defined, evaluates to 0 [-Wundef]
#if SOMEBODY_FIXED_LDEXP
    ^
1 warning generated.
compiling ../../../../ext/cbor/unpacker_class.c
../../../../ext/cbor/unpacker_class.c:113:1: warning: function 'raise_unpacker_error' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
{
^
1 warning generated.
```

That said, the first one looks like a TODO/wishlist (fixable by changing it to something like `#if 0 && SOMEBODY_FIXED_LDEXP` or just `ifdef`) and the second one looks like compiler hint to add `_Noreturn` specifier to the mentioned function.

The main purpose of this PR for me is to get the gem compiles on clang 16 so I didn't touch them.