### PR TITLE
Use xfree for memory from ALLOC_N 

### DIFF
--- a/ext/cbor/buffer_class.c
+++ b/ext/cbor/buffer_class.c
@@ -58,7 +58,7 @@ static void Buffer_free(void* data)
     }
     msgpack_buffer_t* b = (msgpack_buffer_t*) data;
     msgpack_buffer_destroy(b);
-    free(b);
+    xfree(b);
 }
 
 static VALUE Buffer_alloc(VALUE klass)

--- a/ext/cbor/packer_class.c
+++ b/ext/cbor/packer_class.c
@@ -52,7 +52,7 @@ static void Packer_free(msgpack_packer_t* pk)
         return;
     }
     msgpack_packer_destroy(pk);
-    free(pk);
+    xfree(pk);
 }
 
 static VALUE Packer_alloc(VALUE klass)

--- a/ext/cbor/unpacker_class.c
+++ b/ext/cbor/unpacker_class.c
@@ -52,7 +52,7 @@ static void Unpacker_free(msgpack_unpacker_t* uk)
         return;
     }
     msgpack_unpacker_destroy(uk);
-    free(uk);
+    xfree(uk);
 }
 
 static VALUE Unpacker_alloc(VALUE klass)


### PR DESCRIPTION
We use ALLOC_N in Packer_alloc, which is a form of xmalloc so we need to pair that with an xfree otherwise Ruby's internal accounting won't be away aware the memory has been freed and may cause additional unnecessary major GC.


**Before**

```
$ be ruby -e 'require "cbor"; 10.times { 10_000.times { CBOR::Packer.allocate }; GC.start(full_mark: false); p GC.stat(:oldmalloc_increase_bytes) }'
3638080
0
2080000
4160000
6240000
8320000
10400000
12480000
14560000
16640000
```

**After**

```
$ be ruby -e 'require "cbor"; 10.times { 10_000.times { CBOR::Packer.allocate }; GC.start(full_mark: false); p GC.stat(:oldmalloc_increase_bytes) }'
1558304
0
208
208
208
208
208
208
208
208
```