### PR TITLE
Remove std compile flag

### DIFF
--- a/ext/cbor/extconf.rb
+++ b/ext/cbor/extconf.rb
@@ -9,7 +9,7 @@ have_func("rb_sym2str", ["ruby.h"])
 have_func("rb_str_intern", ["ruby.h"])
 have_func("rb_integer_unpack", ["ruby.h"])
 
-$CFLAGS << %[ -I.. -Wall -O3 -g -std=c99]
+$CFLAGS << %[ -I.. -Wall -O3 -g]
 #$CFLAGS << %[ -DDISABLE_RMEM]
 #$CFLAGS << %[ -DDISABLE_RMEM_REUSE_INTERNAL_FRAGMENT]
 #$CFLAGS << %[ -DDISABLE_BUFFER_READ_REFERENCE_OPTIMIZE]


### PR DESCRIPTION
Fixes https://github.com/cabo/cbor-ruby/issues/27

GCC 15 was released on April and is starting to be rolled into distros package managers. For some reason the extension compilation fails when used with GCC 15 with some type errors (I suspect some import path rule changed as inspecting the files do show the types correctly imported).

It is exactly the same as [this bug](https://bugs.ruby-lang.org/issues/21290) reported on Fedora 42 and seems to be related to this [GCC regresion bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118717) but I'm not 100% sure as they talk about some errors coming up when LTOs are enabled (which I'm not sure whether they are or not enabled). May also be related to [this other bug](https://bugs.ruby-lang.org/issues/20908) but they report that GCC 15 defaults to C23 and _that_ makes extension builds fail.

Anyways, removing the flag and letting gcc use its default value seems to work fine for GCC14 and GCC15