### PR TITLE
Fix build failure on mswin (MSVC)

### DIFF
--- a/ext/cbor/packer.h
+++ b/ext/cbor/packer.h
@@ -358,7 +358,7 @@ void msgpack_packer_write_value(msgpack_packer_t* pk, VALUE v);
 
 static inline void msgpack_packer_write_tagged_value(msgpack_packer_t* pk, VALUE v)
 {
-  cbor_encoder_write_head(pk, IB_TAG, rb_num2ulong(rb_struct_aref(v, INT2FIX(0))));
+  cbor_encoder_write_head(pk, IB_TAG, rb_num2ull(rb_struct_aref(v, INT2FIX(0))));
   msgpack_packer_write_value(pk, rb_struct_aref(v, INT2FIX(1)));
 }
 

--- a/ext/cbor/packer.h
+++ b/ext/cbor/packer.h
@@ -268,11 +268,13 @@ static inline void msgpack_packer_write_bignum_value(msgpack_packer_t* pk, VALUE
     cbor_encoder_write_head(pk, IB_BYTES, len);
     msgpack_buffer_ensure_writable(PACKER_BUFFER_(pk), len);
 
-    char buf[len];              /* XXX */
+    VALUE buf_v;
+    char *buf = ALLOCV_N(char, buf_v, len); /* MSVC C has no VLA */
     if (rb_integer_pack(v, buf, len, 1, 0, INTEGER_PACK_BIG_ENDIAN) != 1)
       rb_raise(rb_eRangeError, "cbor rb_integer_pack() error");
 
     msgpack_buffer_append(PACKER_BUFFER_(pk), buf, len);
+    ALLOCV_END(buf_v);
 
 #else
 


### PR DESCRIPTION
MSVC does not support C99 variable-length arrays, so `char buf[len]` in `msgpack_packer_write_bignum_value` fails to compile on x64-mswin64 with C2057/C2466/C2133. This replaces the VLA with `ALLOCV_N`, which allocates a GC-managed temporary buffer and stays safe across `rb_raise`.

With the build fixed, the "Tagged" spec still failed on Windows because `unsigned long` is 32-bit there and `rb_num2ulong` raises `RangeError` for tags above 0xffffffff. `cbor_encoder_write_head` takes `uint64_t`, so tag values are now converted with `rb_num2ull`. Behavior on LP64 platforms is unchanged.

Verified on `x64-mswin64_140` (Ruby 4.0.5, MSVC 14.51) with `gem build` and `gem install`, and the RSpec suite passes with 170 examples, 0 failures.
